### PR TITLE
Modified pipeline to use explicit pre-commit version

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owners
+*   @ElectroRoute-Japan/Admins

--- a/README.md
+++ b/README.md
@@ -1,15 +1,9 @@
-this action is in maintenance-only mode and will not be accepting new features.
-
-generally you want to use [pre-commit.ci] which is faster and has more features.
-
-[pre-commit.ci]: https://pre-commit.ci
-
-___
+This action has been cloned from [![pre-commit](https://github.com/pre-commit/action)](https://github.com/pre-commit/action) to ensure we have the functionality as we need it.
 
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/pre-commit/action/main.svg)](https://results.pre-commit.ci/latest/github/pre-commit/action/main)
-[![Build Status](https://github.com/pre-commit/action/actions/workflows/main.yml/badge.svg)](https://github.com/pre-commit/action/actions)
+[![Build Status](https://github.com/ElectroRoute-Japan/pre-commit-action/actions/workflows/main.yml/badge.svg)](https://github.com/pre-commit/action/actions)
 
-pre-commit/action
+ElectroRoute-Japan/pre-commit-action
 =================
 
 a GitHub action to run [pre-commit](https://pre-commit.com)
@@ -33,7 +27,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v3
-    - uses: pre-commit/action@v3.0.1
+    - uses: ElectroRoute-Japan/pre-commit-action@v1.0.0
 ```
 
 This does a few things:
@@ -51,7 +45,7 @@ Here's a sample step configuration that only runs the `flake8` hook against all
 the files (use the template above except for the `pre-commit` action):
 
 ```yaml
-    - uses: pre-commit/action@v3.0.1
+    - uses: ElectroRoute-Japan/pre-commit-action@v1.0.0
       with:
         extra_args: flake8 --all-files
 ```

--- a/action.yml
+++ b/action.yml
@@ -5,10 +5,20 @@ inputs:
     description: options to pass to pre-commit run
     required: false
     default: '--all-files'
+  version:
+    description: pre-commit version
+    required: false
+    default: ''
 runs:
   using: composite
   steps:
-  - run: python -m pip install pre-commit
+  - id: Install pre-commit (latest)
+    if: ${{ inputs.version == '' }}
+    run: python -m pip install pre-commit
+    shell: bash
+  - id: Install pre-commit ${{ inputs.version }}
+    if: ${{ inputs.version != '' }}
+    run: python -m pip install pre-commit==${{ inputs.version }}
     shell: bash
   - run: python -m pip freeze --local
     shell: bash


### PR DESCRIPTION
This PR modifies the pre-commit pipeline to inject a version argument, allowing users to configure exactly which version of pre-commit they're installing. This is important because v4.0.0 can break pipelines.